### PR TITLE
update tracking id for 2022

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -48,7 +48,7 @@ module.exports  = {
       resolve: `gatsby-plugin-google-gtag`,
       options: {
         trackingIds: [
-          "UA-103407400-1",
+          "G-3KN0M0HRMD",
         ],
         pluginConfig: {
           // Puts tracking script in the head instead of the body


### PR DESCRIPTION
Updated tracking id, since the previous one was getting used for 2019 site.